### PR TITLE
Improve panic stacktrace collection

### DIFF
--- a/hatpear.go
+++ b/hatpear.go
@@ -140,12 +140,12 @@ func (e PanicError) StackTrace() []runtime.Frame {
 
 // Format formats the error optionally including the stack trace.
 //
-//   %s		the error message
-//   %v     the error message and the source file and line number for each stack frame
+//   %s    the error message
+//   %v    the error message and the source file and line number for each stack frame
 //
 // Format accepts the following flags:
 //
-//   %+v	the error message, and the function, file, and line for each stack frame
+//   %+v   the error message, and the function, file, and line for each stack frame
 func (e PanicError) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 's':


### PR DESCRIPTION
Use runtime.Callers instead of collecting a pre-formatted trace. As part of this, hide the implementation details of PanicError and add new formatting methods. The new implementation is similar to that in pkg/errors, but is not directly compatible.

This is a breaking change for clients that use `PanicError`, but I'm pretty sure I'm the only person using this library.