### PR TITLE
Do not store nil errors in the context

### DIFF
--- a/hatpear.go
+++ b/hatpear.go
@@ -28,7 +28,10 @@ func Store(r *http.Request, err error) {
 	if !ok {
 		panic("hatpear: request not configured to store errors")
 	}
-	*errptr = err
+	// check err after checking context to fail fast if unconfigured
+	if err != nil {
+		*errptr = err
+	}
 }
 
 // Get retrieves an error from the request's context. It returns nil if the
@@ -78,7 +81,8 @@ func (f HandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 // request's context.
 func Try(h Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		Store(r, h.ServeHTTP(w, r))
+		err := h.ServeHTTP(w, r)
+		Store(r, err)
 	})
 }
 

--- a/hatpear_test.go
+++ b/hatpear_test.go
@@ -14,8 +14,13 @@ import (
 func TestStoreGet(t *testing.T) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		err := errors.New("test error")
-		hatpear.Store(r, err)
 
+		hatpear.Store(r, err)
+		if stored := hatpear.Get(r); stored != err {
+			t.Errorf("Stored error (%v) does not equal expected error (%v)", stored, err)
+		}
+
+		hatpear.Store(r, nil)
 		if stored := hatpear.Get(r); stored != err {
 			t.Errorf("Stored error (%v) does not equal expected error (%v)", stored, err)
 		}


### PR DESCRIPTION
Avoid overwriting previous errors if callers unconditionally call `Store` or if calls to `Store` are mixed with usage of `Try`.

Fixes #2.